### PR TITLE
Add inventory forecasting page

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,6 +11,7 @@ A comprehensive dashboard for car wash business management with data analytics a
 - Invoices management with advanced filtering
 - Location-based analytics and category heatmaps
 - Inventory and expense tracking
+- Inventory forecasting to estimate replenishment dates
 - Data Assistant powered by OpenAI for natural language business insights
 - Authentication and role-based authorization via Supabase
 
@@ -101,6 +102,11 @@ Example queries:
 - "Which location had the highest equipment expenses last quarter?"
 
 Note: Data searches are limited to the last 6 months for performance reasons.
+
+## Inventory Forecasting
+
+Use the Inventory Forecast page to view estimated replenishment dates for each SKU. The
+forecasts are generated from historical invoice data and can be accessed at `/inventory-forecast` or via the Predictive Inventory card on the AI page.
 
 ## Contributing
 

--- a/app/ai/page.tsx
+++ b/app/ai/page.tsx
@@ -1,6 +1,7 @@
 "use client"
 import { MobileNav } from "@/components/mobile-nav"
 import { useRequireAuth } from "@/hooks/use-auth"
+import Link from "next/link"
 
 export default function AIPage() {
   const loading = useRequireAuth()
@@ -27,9 +28,9 @@ export default function AIPage() {
             </div>
             <h3 className="font-semibold text-xl text-white">Predictive Inventory</h3>
             <p className="text-slate-400">AI-powered inventory forecasting to optimize chemical and equipment stock levels.</p>
-            <button className="bg-slate-800 hover:bg-slate-700 text-white px-4 py-2 rounded-lg mt-2 transition-colors">
-              Coming Soon
-            </button>
+            <Link href="/inventory-forecast" className="bg-slate-800 hover:bg-slate-700 text-white px-4 py-2 rounded-lg mt-2 transition-colors">
+              View Forecast
+            </Link>
           </div>
           
           <div className="col-span-1 bg-slate-900 border border-slate-800 rounded-xl p-6 flex flex-col gap-4">

--- a/app/api/inventory/forecast/route.ts
+++ b/app/api/inventory/forecast/route.ts
@@ -1,0 +1,34 @@
+import { NextResponse } from 'next/server'
+import { forecastInventory } from '@/lib/server-actions'
+
+export async function POST(request: Request) {
+  try {
+    const body = await request.json()
+    const {
+      dateFrom = undefined,
+      dateTo = undefined,
+      location = undefined,
+      category = undefined,
+      locations = undefined,
+      categories = undefined,
+    } = body
+
+    const locationParam = location || (Array.isArray(locations) && locations.length === 1 ? locations[0] : locations)
+    const categoryParam = category || (Array.isArray(categories) && categories.length === 1 ? categories[0] : categories)
+
+    const data = await forecastInventory({
+      dateFrom,
+      dateTo,
+      location: locationParam,
+      category: categoryParam,
+    })
+
+    return NextResponse.json(data)
+  } catch (error) {
+    console.error('API route error:', error)
+    return NextResponse.json(
+      { error: 'Failed to forecast inventory' },
+      { status: 500 }
+    )
+  }
+}

--- a/app/inventory-forecast/page.tsx
+++ b/app/inventory-forecast/page.tsx
@@ -1,0 +1,82 @@
+"use client"
+import { useEffect, useState } from "react"
+import Link from "next/link"
+import { useRequireAuth } from "@/hooks/use-auth"
+import { Table, TableBody, TableCell, TableHead, TableHeader, TableRow } from "@/components/ui/table"
+
+interface ForecastItem {
+  sku: string
+  description: string
+  avgDaysBetween: number | null
+  purchaseCount: number
+  lastPurchaseDate: string | null
+  nextReplenishmentDate: string | null
+}
+
+export default function InventoryForecastPage() {
+  const authLoading = useRequireAuth()
+  const [data, setData] = useState<ForecastItem[]>([])
+  const [loading, setLoading] = useState(true)
+
+  useEffect(() => {
+    async function load() {
+      try {
+        const res = await fetch("/api/inventory/forecast", { method: "POST", body: JSON.stringify({}) })
+        const json = await res.json()
+        setData(json)
+      } catch (err) {
+        console.error("Error loading forecast", err)
+      } finally {
+        setLoading(false)
+      }
+    }
+    load()
+  }, [])
+
+  if (authLoading) return null
+
+  return (
+    <div className="flex min-h-screen flex-col">
+      <div className="flex-1 space-y-6 p-6 md:p-8">
+        <h1 className="text-3xl font-bold text-white mb-6">Inventory Forecast</h1>
+        <div className="rounded-lg border border-slate-800 bg-slate-900 p-4">
+          <Table>
+            <TableHeader className="bg-slate-800">
+              <TableRow>
+                <TableHead className="text-slate-300">SKU</TableHead>
+                <TableHead className="text-slate-300">Description</TableHead>
+                <TableHead className="text-slate-300">Next Replenishment</TableHead>
+              </TableRow>
+            </TableHeader>
+            <TableBody>
+              {loading ? (
+                <TableRow>
+                  <TableCell colSpan={3} className="text-center py-8">
+                    Loading...
+                  </TableCell>
+                </TableRow>
+              ) : data.length ? (
+                data.map((item, idx) => (
+                  <TableRow key={idx} className="border-slate-800">
+                    <TableCell>{item.sku}</TableCell>
+                    <TableCell>{item.description}</TableCell>
+                    <TableCell>{item.nextReplenishmentDate || "N/A"}</TableCell>
+                  </TableRow>
+                ))
+              ) : (
+                <TableRow>
+                  <TableCell colSpan={3} className="text-center py-8">
+                    No data
+                  </TableCell>
+                </TableRow>
+              )}
+            </TableBody>
+          </Table>
+        </div>
+        <div>
+          <Link href="/dashboard" className="text-emerald-400 hover:underline">&larr; Back to Dashboard</Link>
+        </div>
+      </div>
+    </div>
+  )
+}


### PR DESCRIPTION
## Summary
- compute inventory forecast server action
- expose forecast API route
- add Inventory Forecast page with table
- link AI page card to new forecast page
- document forecasting feature

## Testing
- `npm run lint` *(fails: `next` not found)*