### PR TITLE
Add basic AI forecasting endpoint

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,10 +41,12 @@ npm install
 NEXT_PUBLIC_SUPABASE_URL=your_supabase_url
 NEXT_PUBLIC_SUPABASE_ANON_KEY=your_supabase_anon_key
 OPENAI_API_KEY=your_openai_api_key
+OPENAI_MODEL=gpt-3.5-turbo # optional
 ```
 
 4. Replace the placeholders with your actual API keys:
    - Get your OpenAI API key from [https://platform.openai.com/api-keys](https://platform.openai.com/api-keys)
+   - `OPENAI_MODEL` can be set to control which model is used (defaults to `gpt-3.5-turbo`)
    - Get your Supabase credentials from your Supabase project dashboard
 
 5. Run the development server:

--- a/app/ai/page.tsx
+++ b/app/ai/page.tsx
@@ -1,6 +1,7 @@
 "use client"
 import { MobileNav } from "@/components/mobile-nav"
 import { useRequireAuth } from "@/hooks/use-auth"
+import InventoryForecastForm from "@/components/inventory-forecast-form"
 
 export default function AIPage() {
   const loading = useRequireAuth()
@@ -27,9 +28,7 @@ export default function AIPage() {
             </div>
             <h3 className="font-semibold text-xl text-white">Predictive Inventory</h3>
             <p className="text-slate-400">AI-powered inventory forecasting to optimize chemical and equipment stock levels.</p>
-            <button className="bg-slate-800 hover:bg-slate-700 text-white px-4 py-2 rounded-lg mt-2 transition-colors">
-              Coming Soon
-            </button>
+            <InventoryForecastForm />
           </div>
           
           <div className="col-span-1 bg-slate-900 border border-slate-800 rounded-xl p-6 flex flex-col gap-4">

--- a/app/api/inventory/forecast/route.ts
+++ b/app/api/inventory/forecast/route.ts
@@ -1,0 +1,16 @@
+import { NextResponse } from 'next/server'
+import { forecastSkuDemand } from '@/lib/server-actions'
+
+export async function POST(request: Request) {
+  try {
+    const { sku } = await request.json()
+    if (!sku) {
+      return NextResponse.json({ error: 'SKU required' }, { status: 400 })
+    }
+    const result = await forecastSkuDemand(sku)
+    return NextResponse.json({ forecast: result })
+  } catch (err) {
+    console.error('Forecast API error:', err)
+    return NextResponse.json({ error: 'Failed to generate forecast' }, { status: 500 })
+  }
+}

--- a/components/inventory-forecast-form.tsx
+++ b/components/inventory-forecast-form.tsx
@@ -1,0 +1,47 @@
+"use client"
+import { useState } from "react"
+import { Button } from "@/components/ui/button"
+
+export default function InventoryForecastForm() {
+  const [sku, setSku] = useState("")
+  const [forecast, setForecast] = useState<any>(null)
+  const [loading, setLoading] = useState(false)
+
+  const handleSubmit = async () => {
+    if (!sku) return
+    setLoading(true)
+    setForecast(null)
+    try {
+      const res = await fetch("/api/inventory/forecast", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ sku }),
+      })
+      const data = await res.json()
+      setForecast(data.forecast)
+    } catch (err) {
+      console.error(err)
+    } finally {
+      setLoading(false)
+    }
+  }
+
+  return (
+    <div className="space-y-2 mt-2">
+      <input
+        value={sku}
+        onChange={(e) => setSku(e.target.value)}
+        placeholder="Enter SKU"
+        className="w-full bg-slate-800 border border-slate-700 rounded-lg px-3 py-2 text-white"
+      />
+      <Button onClick={handleSubmit} disabled={loading || !sku} className="w-full bg-slate-800 hover:bg-slate-700">
+        {loading ? "Loading..." : "Get Forecast"}
+      </Button>
+      {forecast && (
+        <pre className="whitespace-pre-wrap break-words text-sm text-slate-300 bg-slate-800 p-2 rounded-lg">
+          {JSON.stringify(forecast, null, 2)}
+        </pre>
+      )}
+    </div>
+  )
+}


### PR DESCRIPTION
## Summary
- implement `forecastSkuDemand` in server actions
- expose `/api/inventory/forecast` endpoint
- add InventoryForecastForm component and hook it into the AI page
- document `OPENAI_MODEL` in README

## Testing
- `npx tsc --noEmit` *(fails: numerous missing type declarations)*